### PR TITLE
Allow missing value in SSM

### DIFF
--- a/src/test/scala/example/Example.scala
+++ b/src/test/scala/example/Example.scala
@@ -12,13 +12,14 @@ class Example {
   implicit val region: Regions = Regions.EU_WEST_1
   implicit val credsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain
 
-  case class Config(username: String, password: String, port: Int)
+  case class Config(username: String, password: String, port: Int, alwaysNone: Option[String])
 
   val config = loadConfig(
     param[String]("password"),
-    param[Int]("port")
-  ) { (password, port) =>
-    Config(username = "Dave", password = password, port = port)
+    param[Int]("port"),
+    param[Option[String]]("an-absolutely-random-entry")
+  ) { (password, port, alwaysNone) =>
+    Config(username = "Dave", password = password, port = port, alwaysNone = alwaysNone)
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.1-SNAPSHOT"
+version in ThisBuild := "0.12.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.1"
+version in ThisBuild := "0.12.2-SNAPSHOT"


### PR DESCRIPTION
This provides the support to handle missing value in SSM, by returning None in case of `ParameterNotFoundException` from SSM client.