### PR TITLE
Add environment support for region

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,8 @@ import ciris.aws.ssm._
 import com.amazonaws.auth._
 import com.amazonaws.regions.Regions
 
-// the region can be overridden using an implicit
+/* The region defaults to eu-west-1, unless overriden by "AWS_REGION" in the environment
+ * This can be overridden in code by setting AWS_REGION using an implicit */
 implicit val region: Regions =
   Regions.EU_WEST_1
 

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.simplesystemsmanagement._
 package object ssm {
   final def params[F[_]](blocker: Blocker)(
     implicit F: Sync[F],
-    region: Regions = Regions.EU_WEST_1,
+    region: Regions = sys.env.get("AWS_REGION").map(Regions.fromName).getOrElse(Regions.EU_WEST_1),
     credsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
   ): Resource[F, Param] =
     Resource {


### PR DESCRIPTION
I spent ten minutes tracing `Missing parameter FOOBAR from AWS SSM`, before I discovered the default of EU-WEST-1.   (It would be helpful if ciris' core would include region information in the not-found error messages)

I'm proposing this change, which observes the SDK's AWS_REGION parameter in the environment.  This would make for better multi-region support without consumers needing to code implicit logic, i.e. 

```scala
implicit var region: Regions = sys.env.get("AWS_REGION").map(Regions.fromName).getOrElse(Regions.WHATEVER),
```

Downside is, this change could surprise consumers who are now relying on EU-WEST-1 defaults but have an `AWS_REGION` var set. 

