### PR TITLE
Enable setting region based on other configuration sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,6 @@ crossScalaVersions := Seq(scalaVersion.value, "2.12.10")
 releaseCrossBuild := true
 
 libraryDependencies ++= Seq(
-  "is.cir" %% "ciris" % "1.0.1",
+  "is.cir" %% "ciris" % "1.0.4+62-0d574645+20200422-1805-SNAPSHOT",
   "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.667"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,6 @@ crossScalaVersions := Seq(scalaVersion.value, "2.12.10")
 releaseCrossBuild := true
 
 libraryDependencies ++= Seq(
-  "is.cir" %% "ciris" % "1.0.4+62-0d574645+20200422-1805-SNAPSHOT",
+  "is.cir" %% "ciris" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.667"
 )

--- a/readme.md
+++ b/readme.md
@@ -25,16 +25,6 @@ import cats.effect.{Blocker, ExitCode, IO, IOApp}
 import cats.implicits._
 import ciris._
 import ciris.aws.ssm._
-import com.amazonaws.auth._
-import com.amazonaws.regions.Regions
-
-// the region can be overridden using an implicit
-implicit val region: Regions =
-  Regions.EU_WEST_1
-
-// the credentials provider can be overridden using an implicit
-implicit val credsProvider: AWSCredentialsProvider =
-  new DefaultAWSCredentialsProviderChain
 
 final case class Config(
   username: String,
@@ -45,23 +35,27 @@ final case class Config(
 
 object Main extends IOApp {
   def run(args: List[String]): IO[ExitCode] =
-    Blocker[IO].flatMap(params[IO]).use { param =>
+    Blocker[IO].use { blocker =>
       val config =
-        (
-          param("password"),
-          param("port").as[Int],
-          param("api-key").option
-        ).parMapN { (password, port, apiKey) =>
-          Config(
-            username = "Dave",
-            password = password,
-            port = port,
-            apiKey = apiKey
-          )
-        }
+        for {
+          region <- env("AWS_REGION").as[Region].default(Region.EU_WEST_1)
+          param <- params[IO](blocker, region)
+          config <- (
+              param("password"),
+              param("port").as[Int],
+              param("api-key").option
+            ).parMapN { (password, port, apiKey) =>
+              Config(
+                username = "Dave",
+                password = password,
+                port = port,
+                apiKey = apiKey
+              )
+            }
+        } yield config
 
-      config.load[IO]
-    }.as(ExitCode.Success)
+      config.load[IO].as(ExitCode.Success)
+    }
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ object Main extends IOApp {
       val config =
         for {
           region <- env("AWS_REGION").as[Region].default(Region.EU_WEST_1)
-          param <- params[IO](blocker, region)
+          param <- params(blocker, region)
           config <- (
               param("password"),
               param("port").as[Int],

--- a/src/main/scala/ciris/aws/ssm/Param.scala
+++ b/src/main/scala/ciris/aws/ssm/Param.scala
@@ -1,7 +1,7 @@
 package ciris.aws.ssm
 
 import cats.effect.Blocker
-import ciris._
+import ciris.{ConfigKey, ConfigValue}
 import com.amazonaws.services.simplesystemsmanagement._
 import com.amazonaws.services.simplesystemsmanagement.model._
 

--- a/src/main/scala/ciris/aws/ssm/Region.scala
+++ b/src/main/scala/ciris/aws/ssm/Region.scala
@@ -1,0 +1,73 @@
+package ciris.aws.ssm
+
+import cats.implicits._
+import ciris.ConfigDecoder
+import com.amazonaws.regions.Regions
+
+sealed abstract class Region(val asJava: Regions) {
+  final def name: String =
+    asJava.getName()
+
+  final def description: String =
+    asJava.getDescription()
+}
+
+object Region {
+  case object AP_EAST_1 extends Region(Regions.AP_EAST_1)
+  case object AP_NORTHEAST_1 extends Region(Regions.AP_NORTHEAST_1)
+  case object AP_NORTHEAST_2 extends Region(Regions.AP_NORTHEAST_2)
+  case object AP_SOUTH_1 extends Region(Regions.AP_SOUTH_1)
+  case object AP_SOUTHEAST_1 extends Region(Regions.AP_SOUTHEAST_1)
+  case object AP_SOUTHEAST_2 extends Region(Regions.AP_SOUTHEAST_2)
+  case object CA_CENTRAL_1 extends Region(Regions.CA_CENTRAL_1)
+  case object CN_NORTH_1 extends Region(Regions.CN_NORTH_1)
+  case object CN_NORTHWEST_1 extends Region(Regions.CN_NORTHWEST_1)
+  case object EU_CENTRAL_1 extends Region(Regions.EU_CENTRAL_1)
+  case object EU_NORTH_1 extends Region(Regions.EU_NORTH_1)
+  case object EU_WEST_1 extends Region(Regions.EU_WEST_1)
+  case object EU_WEST_2 extends Region(Regions.EU_WEST_2)
+  case object EU_WEST_3 extends Region(Regions.EU_WEST_3)
+  case object GovCloud extends Region(Regions.GovCloud)
+  case object ME_SOUTH_1 extends Region(Regions.ME_SOUTH_1)
+  case object SA_EAST_1 extends Region(Regions.SA_EAST_1)
+  case object US_EAST_1 extends Region(Regions.US_EAST_1)
+  case object US_EAST_2 extends Region(Regions.US_EAST_2)
+  case object US_GOV_EAST_1 extends Region(Regions.US_GOV_EAST_1)
+  case object US_WEST_1 extends Region(Regions.US_WEST_1)
+  case object US_WEST_2 extends Region(Regions.US_WEST_2)
+
+  def apply(region: Regions): Region =
+    region match {
+      case Regions.AP_EAST_1      => Region.AP_EAST_1
+      case Regions.AP_NORTHEAST_1 => Region.AP_NORTHEAST_1
+      case Regions.AP_NORTHEAST_2 => Region.AP_NORTHEAST_2
+      case Regions.AP_SOUTH_1     => Region.AP_SOUTH_1
+      case Regions.AP_SOUTHEAST_1 => Region.AP_SOUTHEAST_1
+      case Regions.AP_SOUTHEAST_2 => Region.AP_SOUTHEAST_2
+      case Regions.CA_CENTRAL_1   => Region.CA_CENTRAL_1
+      case Regions.CN_NORTH_1     => Region.CN_NORTH_1
+      case Regions.CN_NORTHWEST_1 => Region.CN_NORTHWEST_1
+      case Regions.EU_CENTRAL_1   => Region.EU_CENTRAL_1
+      case Regions.EU_NORTH_1     => Region.EU_NORTH_1
+      case Regions.EU_WEST_1      => Region.EU_WEST_1
+      case Regions.EU_WEST_2      => Region.EU_WEST_2
+      case Regions.EU_WEST_3      => Region.EU_WEST_3
+      case Regions.GovCloud       => Region.GovCloud
+      case Regions.ME_SOUTH_1     => Region.ME_SOUTH_1
+      case Regions.SA_EAST_1      => Region.SA_EAST_1
+      case Regions.US_EAST_1      => Region.US_EAST_1
+      case Regions.US_EAST_2      => Region.US_EAST_2
+      case Regions.US_GOV_EAST_1  => Region.US_GOV_EAST_1
+      case Regions.US_WEST_1      => Region.US_WEST_1
+      case Regions.US_WEST_2      => Region.US_WEST_2
+    }
+
+  def unapply(region: Region): Some[Regions] =
+    Some(region.asJava)
+
+  def fromName(name: String): Option[Region] =
+    Regions.values.find(_.name == name).map(apply)
+
+  implicit val regionConfigDecoder: ConfigDecoder[String, Region] =
+    ConfigDecoder[String].mapOption("Region")(fromName)
+}

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -1,25 +1,25 @@
 package ciris.aws
 
-import cats.effect.{Blocker, Effect, Resource}
+import cats.effect.{Blocker, Effect, IO, Resource}
 import ciris.ConfigValue
 import com.amazonaws.auth._
 import com.amazonaws.services.simplesystemsmanagement._
 
 package object ssm {
-  def params[F[_]](
+  def params(
     blocker: Blocker,
     region: Region
-  )(implicit F: Effect[F]): ConfigValue[Param] =
+  ): ConfigValue[Param] =
     params(blocker, region, new DefaultAWSCredentialsProviderChain())
 
-  def params[F[_]](
+  def params(
     blocker: Blocker,
     region: Region,
     credentials: AWSCredentialsProvider
-  )(implicit F: Effect[F]): ConfigValue[Param] =
+  ): ConfigValue[Param] =
     ConfigValue.resource {
       Resource {
-        F.delay {
+        IO {
           val client =
             AWSSimpleSystemsManagementClientBuilder
               .standard()
@@ -28,7 +28,7 @@ package object ssm {
               .build()
 
           val shutdown =
-            F.delay(client.shutdown())
+            IO(client.shutdown())
 
           (ConfigValue.default(Param(client, blocker)), shutdown)
         }

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -3,7 +3,6 @@ package ciris.aws
 import cats.effect.{Blocker, Effect, Resource}
 import ciris.ConfigValue
 import com.amazonaws.auth._
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.simplesystemsmanagement._
 
 package object ssm {
@@ -16,7 +15,7 @@ package object ssm {
   def params[F[_]](
     blocker: Blocker,
     region: Region,
-    credsProvider: AWSCredentialsProvider
+    credentials: AWSCredentialsProvider
   )(implicit F: Effect[F]): ConfigValue[Param] =
     ConfigValue.resource {
       Resource {
@@ -25,7 +24,7 @@ package object ssm {
             AWSSimpleSystemsManagementClientBuilder
               .standard()
               .withRegion(region.asJava)
-              .withCredentials(credsProvider)
+              .withCredentials(credentials)
               .build()
 
           val shutdown =


### PR DESCRIPTION
Alternative to #9 to set region based on other configuration sources (e.g. environment variables).

- The default `EU_WEST_1` region has been removed. It must now always be specified explicitly.
- Both region and credentials must now be passed explicitly, rather than implicitly as before.
- Add custom `Region` representation to enable decoding without importing any implicits.

The example below (from the updated readme) shows how using the `AWS_REGION` environment variable with a default region works.

```scala
import cats.effect.{Blocker, ExitCode, IO, IOApp}
import cats.implicits._
import ciris._
import ciris.aws.ssm._

final case class Config(
  username: String,
  password: String,
  port: Int,
  apiKey: Option[String]
)

object Main extends IOApp {
  def run(args: List[String]): IO[ExitCode] =
    Blocker[IO].use { blocker =>
      val config =
        for {
          region <- env("AWS_REGION").as[Region].default(Region.EU_WEST_1)
          param <- params(blocker, region)
          config <- (
              param("password"),
              param("port").as[Int],
              param("api-key").option
            ).parMapN { (password, port, apiKey) =>
              Config(
                username = "Dave",
                password = password,
                port = port,
                apiKey = apiKey
              )
            }
        } yield config

      config.load[IO].as(ExitCode.Success)
    }
}
```

~Note this still relies on an unpublished snapshot version of Ciris with support for `Resource`.~ Updated to use Ciris v1.1.0 which has support for `Resource`.