### PR TITLE
Update to cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+val catsEffectVersion = "3.1.1"
 lazy val root = (project in file("."))
   .settings(publishOptions)
   .settings(
@@ -7,8 +8,10 @@ lazy val root = (project in file("."))
     scalaVersion := "2.13.1",
     crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
     libraryDependencies ++= Seq(
-      "is.cir" %% "ciris" % "1.2.1",
-      "software.amazon.awssdk" % "ssm" % "2.16.48"
+      "is.cir" %% "ciris" % "2.0.1",
+      "software.amazon.awssdk" % "ssm" % "2.16.78",
+      "org.typelevel" %% "cats-effect-kernel" % catsEffectVersion,
+      "org.typelevel" %% "cats-effect"        % catsEffectVersion
     ),
     scmInfo := Some(
       ScmInfo(

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "is.cir" %% "ciris" % "2.0.1",
       "software.amazon.awssdk" % "ssm" % "2.16.78",
-      "org.typelevel" %% "cats-effect-kernel" % catsEffectVersion,
       "org.typelevel" %% "cats-effect"        % catsEffectVersion
     ),
     scmInfo := Some(

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -1,27 +1,24 @@
 package ciris.aws
 
-import cats.effect.{Blocker, IO, Resource}
+import cats.effect.kernel.{Resource, Sync}
 import ciris.ConfigValue
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider, DefaultCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
 
 package object ssm {
-  def params(
-    blocker: Blocker,
-    region: Region
-  ): ConfigValue[Param] =
-    params(blocker, region, DefaultCredentialsProvider.create())
+  def params[F[_]: Sync](region: Region
+  ): ConfigValue[F, Param[F]] =
+    params(region, DefaultCredentialsProvider.create())
 
-  def params(
-    blocker: Blocker,
+  def params[F[_]: Sync](
     region: Region,
     credentials: AwsCredentialsProvider
-  ): ConfigValue[Param] =
+  ): ConfigValue[F, Param[F]] =
     ConfigValue.resource {
       Resource
-        .fromAutoCloseable {
-          IO {
+        .fromAutoCloseable[F, SsmClient] {
+          Sync[F].pure {
             SsmClient
               .builder()
               .region(region)
@@ -30,6 +27,6 @@ package object ssm {
 
           }
         }
-        .map(client => ConfigValue.default(Param(client, blocker)))
+        .map(client => ConfigValue.default(Param[F](client)))
     }
 }

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -18,7 +18,7 @@ package object ssm {
     ConfigValue.resource {
       Resource
         .fromAutoCloseable[F, SsmClient] {
-          Sync[F].pure {
+          Sync[F].delay {
             SsmClient
               .builder()
               .region(region)


### PR DESCRIPTION
Changes
- bump CE to 3.1.1
- bump Ciris to 2.0.1
- bump AWS SSM to 2.16.78

The CE and Ciris version bumps require breaking changes to this library's interfaces as
- `Blocker` no longer exists in CE
- `ConfigValue` from Ciris now takes an `F[_]` type parameter