### PR TITLE
Fix SSM client lifecycle and DefaultCredentialsProvider handling

### DIFF
--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -35,7 +35,7 @@ package object ssm {
     params(SsmAsyncClient.builder().region(region).credentialsProvider(credsProvider))
 
   private def params[F[_]: Async](builder: SsmAsyncClientBuilder): ConfigValue[F, Param[F]] =
-    ConfigValue.resource(Resource.fromAutoCloseable(Sync[F].delay(builder.build())).map(params))
+    ConfigValue.resource(Resource.fromAutoCloseable(Sync[F].delay(builder.build())).map(params[F]))
 
   /** An asynchronous loader for SSM parameters, using the provided `SsmAsyncClient`
     *

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -2,7 +2,7 @@ package ciris.aws
 
 import cats.effect.{Async, Resource, Sync}
 import ciris.ConfigValue
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.{SsmAsyncClient, SsmAsyncClientBuilder}
 
@@ -30,7 +30,7 @@ package object ssm {
     */
   def params[F[_]: Async](
     region: Region,
-    credsProvider: DefaultCredentialsProvider
+    credsProvider: AwsCredentialsProvider
   ): ConfigValue[F, Param[F]] =
     params(SsmAsyncClient.builder().region(region).credentialsProvider(credsProvider))
 

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -23,7 +23,7 @@ package object ssm {
     */
   def params[F[_]: Async](
     region: Region,
-    credsProvider: DefaultCredentialsProvider = DefaultCredentialsProvider.create()
+    credsProvider: DefaultCredentialsProvider = DefaultCredentialsProvider.builder().build()
   ): ConfigValue[F, Param[F]] = params(
     SsmAsyncClient.builder().region(region).credentialsProvider(credsProvider).build()
   )

--- a/src/main/scala/ciris/aws/ssm/package.scala
+++ b/src/main/scala/ciris/aws/ssm/package.scala
@@ -1,39 +1,48 @@
 package ciris.aws
 
-import cats.effect.Async
-import cats.effect.kernel.{Resource, Sync}
+import cats.effect.{Async, Resource, Sync}
 import ciris.ConfigValue
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.{SsmAsyncClient, SsmAsyncClientBuilder}
 
 package object ssm {
 
   /** An asynchronous loader for SSM parameters, using the default client config */
-  def params[F[_]: Async]: ConfigValue[F, Param[F]] = params(
-    SsmAsyncClient.builder().build()
-  )
+  def params[F[_]: Async]: ConfigValue[F, Param[F]] = params(SsmAsyncClient.builder())
 
-  /** An asynchronous loader for SSM parameters, using the default client config with some overrides
+  /** An asynchronous loader for SSM parameters, otherwise using the default client config with the
+    * given region
+    *
+    * @param region
+    *   The AWS Region
+    */
+  def params[F[_]: Async](region: Region): ConfigValue[F, Param[F]] =
+    params(SsmAsyncClient.builder().region(region))
+
+  /** An asynchronous loader for SSM parameters, using the default client config with the given
+    * region and credentials provider
     *
     * @param region
     *   The AWS Region
     * @param credsProvider
-    *   optional credentials provider to use (default is `DefaultCredentialsProvider`)
+    *   AWS credentials provider to use
     */
   def params[F[_]: Async](
     region: Region,
-    credsProvider: DefaultCredentialsProvider = DefaultCredentialsProvider.builder().build()
-  ): ConfigValue[F, Param[F]] = params(
-    SsmAsyncClient.builder().region(region).credentialsProvider(credsProvider).build()
-  )
+    credsProvider: DefaultCredentialsProvider
+  ): ConfigValue[F, Param[F]] =
+    params(SsmAsyncClient.builder().region(region).credentialsProvider(credsProvider))
 
-  /** An asynchronous loader for SSM parameters, using the provided `SsmClient` */
+  private def params[F[_]: Async](builder: SsmAsyncClientBuilder): ConfigValue[F, Param[F]] =
+    ConfigValue.resource(Resource.fromAutoCloseable(Sync[F].delay(builder.build())).map(params))
+
+  /** An asynchronous loader for SSM parameters, using the provided `SsmAsyncClient`
+    *
+    * @param client
+    *   The SSM client to use. The caller remains responsible for managing its lifecycle.
+    */
   def params[F[_]: Async](client: SsmAsyncClient): ConfigValue[F, Param[F]] =
-    ConfigValue.resource {
-      Resource
-        .fromAutoCloseable[F, SsmAsyncClient](Sync[F].delay(client))
-        .map(client => ConfigValue.default(Param.fromAsync[F](client)))
-    }
+    ConfigValue.default(Param.fromAsync[F](client))
 
 }


### PR DESCRIPTION
Some fixes around unsafe creation and usage of SSM clients and credentials providers. This has necessitated an API change and thus should result in a major version bump.

1) Avoid `DefaultCredentialsProvider.create()` - the name and doc are misleading ([upstream bug](https://github.com/aws/aws-sdk-java-v2/issues/3493)), and it in fact returns a shared instance. When we close an SSM client, this gets closed as well, so if an application also falls for the bug then it'll be unable to use any provider in the DefaultCredentialsProvider's chain that makes an API call (e.g. an EKS workload that needs to refresh its credentials via STS will get a mysterious "connection pool closed" error).

    Even if `DefaultCredentialsProvider.create()` always created a new instance as it claimed, its usage as a default parameter value was still unsafe due to being outside of an effectful Resource. The params factories have been tweaked accordingly, with the default parameter value removed and a new overload added for specifying a region but using the default creds provider (note that all AWS SDK service client builders avoid the issue with `.create()` when you don't specify a provider, because they use DefaultCredentialsProvider's builder instead).

2) Manage the lifecycle of SSM clients properly. We'd been eagerly creating them before pointlessly `delay`ing the resulting value and lifting it into Resource - instead, build them within Resource.

3) Generalise the creds provider parameter in the factory to AwsCredentialsProvider, so that other implementations can be used