### PR TITLE
Issue #363 - Bump ciris to 3.2.0 (and the req'd scala3 version to 3.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,16 @@ lazy val root = (project in file("."))
     name := "ciris-aws-ssm",
     organization := "com.ovoenergy",
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-    scalaVersion := "3.1.3",
-    crossScalaVersions := Seq(scalaVersion.value, "2.13.10", "2.12.10"),
+    scalaVersion := "3.2.2",
+    crossScalaVersions := Seq(scalaVersion.value, "2.13.11", "2.12.10"),
     scalacOptions := (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 12)) => Seq("-Ypartial-unification")
       case _             => Seq.empty
     }),
     libraryDependencies ++= Seq(
-      "is.cir" %% "ciris" % "2.3.3",
-      "software.amazon.awssdk" % "ssm" % "2.18.3",
-      "org.typelevel" %% "cats-effect" % "3.3.14",
+      "is.cir" %% "ciris" % "3.2.0",
+      "software.amazon.awssdk" % "ssm" % "2.20.93",
+      "org.typelevel" %% "cats-effect" % "3.5.1",
       "org.typelevel" %% "munit-cats-effect-3" % "1.0.7" % "test"
     ),
     scmInfo := Some(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.2
+sbt.version = 1.9.0


### PR DESCRIPTION
Raised https://github.com/ovotech/ciris-aws-ssm/pull/364 for this